### PR TITLE
Add OctoPrint gem blog post and fix navigation

### DIFF
--- a/blog/2025-07-14-octoprint-gem-finally-happening.md
+++ b/blog/2025-07-14-octoprint-gem-finally-happening.md
@@ -1,0 +1,27 @@
+---
+slug: octoprint-gem-finally-happening
+title: The Octoprint Gem is Finally Happening (Thanks, AI)
+authors: [sophie]
+tags: [octoprint, ai, open-source, 3d-printing, development, project-logs]
+date: 2025-07-14
+---
+
+# The Octoprint Gem is Finally Happening (Thanks, AI)
+
+I started working on the [Octoprint gem](https://github.com/sophiedeziel/octoprint) back in March 2022. The goal was simple: create a Ruby wrapper around the Octoprint REST API so I could interact with multiple 3D printer servers for another project.
+
+Simple, but incredibly boring.
+
+The work was pure drudgery: read an API endpoint's documentation, create classes for models and errors, write tests, document everything, repeat. I implemented just what I needed and then... let it sit. For years. Untouched except for the occasional Dependabot update.
+
+<!-- truncate -->
+
+Fast forward to last month when I realized this project was perfect for experimenting with AI-assisted development. The patterns were already established, the tests were in place, and I even had a checklist of what was done versus what remained. Each endpoint implementation was basically identical—ideal for testing different approaches to vibecoding.
+
+So I started handing off endpoints to Claude Code, one by one.
+
+The result? The gem is now about 50% complete, and I'm confident I can release a first version within the month. Not because I changed my approach or found new motivation—because AI took over the repetitive parts I was dreading.
+
+There are no more big decisions to make. No architectural puzzles to solve. Just implementation work that AI handles while I focus on the parts that actually interest me.
+
+It's wild how a project that felt abandoned suddenly feels inevitable. Sometimes the barrier isn't complexity—it's just boredom.

--- a/blog/tags.yml
+++ b/blog/tags.yml
@@ -42,3 +42,23 @@ project-logs:
   label: Project Logs
   permalink: /plog
   description: Development logs and progress updates on various projects
+
+octoprint:
+  label: OctoPrint
+  permalink: /octoprint
+  description: Posts about OctoPrint and 3D printing software
+
+vibecoding:
+  label: Vibecoding
+  permalink: /vibecoding
+  description: Posts about energy-driven development and vibecoding
+
+open-source:
+  label: Open Source
+  permalink: /open-source
+  description: Posts about open source software and contributions
+
+3d-printing:
+  label: 3D Printing
+  permalink: /3d-printing
+  description: Posts about 3D printing technology and projects

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -102,7 +102,6 @@ const config = {
             label: 'Docs',
           },
           {to: '/blog', label: 'Blog', position: 'left'},
-          {to: '/blog/tags/til', label: 'Today I Learned', position: 'left'},
           {to: '/blog/tags/plog', label: 'Project Logs', position: 'left'},
           {
             href: 'https://github.com/facebook/docusaurus',

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -102,8 +102,8 @@ const config = {
             label: 'Docs',
           },
           {to: '/blog', label: 'Blog', position: 'left'},
-          {to: '/blog/tags/today-i-learned', label: 'Today I Learned', position: 'left'},
-          {to: '/blog/tags/project-logs', label: 'Project Logs', position: 'left'},
+          {to: '/blog/tags/til', label: 'Today I Learned', position: 'left'},
+          {to: '/blog/tags/plog', label: 'Project Logs', position: 'left'},
           {
             href: 'https://github.com/facebook/docusaurus',
             label: 'GitHub',


### PR DESCRIPTION
## Summary
- Add new blog post: "The Octoprint Gem is Finally Happening (Thanks, AI)"
- Add new blog tags for better categorization (octoprint, vibecoding, open-source, 3d-printing)
- Fix navigation menu links to use correct shortened permalinks (til, plog)

## Test plan
- [x] Blog post displays correctly with proper metadata
- [x] All tags are properly defined and functional
- [x] Navigation menu links work correctly
- [x] Blog post includes link to GitHub repository

🤖 Generated with [Claude Code](https://claude.ai/code)