### PR TITLE
Customize blog post layout and styling

### DIFF
--- a/blog/2025-07-13-simple-question-fixed-prompts.md
+++ b/blog/2025-07-13-simple-question-fixed-prompts.md
@@ -2,7 +2,7 @@
 slug: simple-question-fixed-prompts
 title: The Simple Question That Fixed My Prompts
 authors: [sophie]
-tags: [ai, prompts, collaboration]
+tags: [ai, prompts, collaboration, til]
 date: 2025-07-13
 ---
 

--- a/blog/2025-07-13-simple-question-fixed-prompts.md
+++ b/blog/2025-07-13-simple-question-fixed-prompts.md
@@ -2,7 +2,7 @@
 slug: simple-question-fixed-prompts
 title: The Simple Question That Fixed My Prompts
 authors: [sophie]
-tags: [ai, prompts, collaboration, til]
+tags: [ai, prompts, collaboration]
 date: 2025-07-13
 ---
 

--- a/blog/tags.yml
+++ b/blog/tags.yml
@@ -18,6 +18,16 @@ development:
   permalink: /development
   description: Posts about software development and programming
 
+claude:
+  label: Claude
+  permalink: /claude
+  description: Posts about Claude AI and Claude Code
+
+development-tools:
+  label: Development Tools
+  permalink: /development-tools
+  description: Posts about tools and utilities for software development
+
 tutorials:
   label: Tutorials
   permalink: /tutorials
@@ -33,10 +43,10 @@ personal:
   permalink: /personal
   description: Personal thoughts and experiences
 
-til:
-  label: TIL
+today-i-learned:
+  label: Today I Learned
   permalink: /til
-  description: Today I Learned - Quick lessons and discoveries from daily development
+  description: Quick lessons and discoveries from daily development
 
 project-logs:
   label: Project Logs

--- a/blog/tags.yml
+++ b/blog/tags.yml
@@ -33,10 +33,10 @@ personal:
   permalink: /personal
   description: Personal thoughts and experiences
 
-today-i-learned:
-  label: Today I Learned
+til:
+  label: TIL
   permalink: /til
-  description: Quick lessons and discoveries from daily development
+  description: Today I Learned - Quick lessons and discoveries from daily development
 
 project-logs:
   label: Project Logs

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -61,10 +61,6 @@ const config = {
             type: ['rss', 'atom'],
             xslt: true,
           },
-          // Please change this to your repo.
-          // Remove this to remove the "edit this page" links.
-          editUrl:
-            'https://github.com/facebook/docusaurus/tree/main/packages/create-docusaurus/templates/shared/',
           // Useful options to enforce blogging best practices
           onInlineTags: 'warn',
           onInlineAuthors: 'warn',
@@ -103,6 +99,7 @@ const config = {
             label: 'Docs',
           },
           {to: '/blog', label: 'Blog', position: 'left'},
+          {to: '/blog/tags/til', label: 'TIL', position: 'left'},
           {to: '/blog/tags/plog', label: 'Project Logs', position: 'left'},
           {
             href: 'https://github.com/facebook/docusaurus',

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -28,3 +28,29 @@
   --ifm-color-primary-lightest: #4fddbf;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.3);
 }
+
+/* Blog post customizations */
+.blogPostItemReadMore {
+  margin-bottom: var(--ifm-spacing-vertical);
+}
+
+.blogPostItemReadMore a {
+  font-size: 1.1rem;
+  font-weight: 600;
+  text-decoration: none;
+  color: var(--ifm-color-primary);
+  padding: 0.5rem 0;
+  display: inline-block;
+  transition: all 0.2s ease;
+}
+
+.blogPostItemReadMore a:hover {
+  text-decoration: underline;
+}
+
+.blogPostItemReadingTime {
+  margin-top: 0.25rem;
+  font-size: 0.9rem;
+  color: var(--ifm-color-content-secondary);
+  font-style: italic;
+}

--- a/src/theme/BlogPostItem/Container/index.tsx
+++ b/src/theme/BlogPostItem/Container/index.tsx
@@ -1,0 +1,9 @@
+import React, {type ReactNode} from 'react';
+import type {Props} from '@theme/BlogPostItem/Container';
+
+export default function BlogPostItemContainer({
+  children,
+  className,
+}: Props): ReactNode {
+  return <article className={className}>{children}</article>;
+}

--- a/src/theme/BlogPostItem/Content/index.tsx
+++ b/src/theme/BlogPostItem/Content/index.tsx
@@ -1,0 +1,21 @@
+import React, {type ReactNode} from 'react';
+import clsx from 'clsx';
+import {blogPostContainerID} from '@docusaurus/utils-common';
+import {useBlogPost} from '@docusaurus/plugin-content-blog/client';
+import MDXContent from '@theme/MDXContent';
+import type {Props} from '@theme/BlogPostItem/Content';
+
+export default function BlogPostItemContent({
+  children,
+  className,
+}: Props): ReactNode {
+  const {isBlogPostPage} = useBlogPost();
+  return (
+    <div
+      // This ID is used for the feed generation to locate the main content
+      id={isBlogPostPage ? blogPostContainerID : undefined}
+      className={clsx('markdown', className)}>
+      <MDXContent>{children}</MDXContent>
+    </div>
+  );
+}

--- a/src/theme/BlogPostItem/Footer/ReadMoreLink/index.tsx
+++ b/src/theme/BlogPostItem/Footer/ReadMoreLink/index.tsx
@@ -1,0 +1,37 @@
+import React, {type ReactNode} from 'react';
+import Translate, {translate} from '@docusaurus/Translate';
+import Link from '@docusaurus/Link';
+import type {Props} from '@theme/BlogPostItem/Footer/ReadMoreLink';
+
+function ReadMoreLabel() {
+  return (
+    <b>
+      <Translate
+        id="theme.blog.post.readMore"
+        description="The label used in blog post item excerpts to link to full blog posts">
+        Read more
+      </Translate>
+    </b>
+  );
+}
+
+export default function BlogPostItemFooterReadMoreLink(
+  props: Props,
+): ReactNode {
+  const {blogPostTitle, ...linkProps} = props;
+  return (
+    <Link
+      aria-label={translate(
+        {
+          message: 'Read more about {title}',
+          id: 'theme.blog.post.readMoreLabel',
+          description:
+            'The ARIA label for the link to full blog posts from excerpts',
+        },
+        {title: blogPostTitle},
+      )}
+      {...linkProps}>
+      <ReadMoreLabel />
+    </Link>
+  );
+}

--- a/src/theme/BlogPostItem/Footer/index.tsx
+++ b/src/theme/BlogPostItem/Footer/index.tsx
@@ -1,0 +1,89 @@
+import React, {type ReactNode} from 'react';
+import clsx from 'clsx';
+import {useBlogPost} from '@docusaurus/plugin-content-blog/client';
+import {ThemeClassNames} from '@docusaurus/theme-common';
+import EditMetaRow from '@theme/EditMetaRow';
+import TagsListInline from '@theme/TagsListInline';
+import ReadMoreLink from '@theme/BlogPostItem/Footer/ReadMoreLink';
+import BlogPostItemHeaderAuthors from '@theme/BlogPostItem/Header/Authors';
+
+export default function BlogPostItemFooter(): ReactNode {
+  const {metadata, isBlogPostPage} = useBlogPost();
+  const {
+    tags,
+    title,
+    editUrl,
+    hasTruncateMarker,
+    lastUpdatedBy,
+    lastUpdatedAt,
+  } = metadata;
+
+  // A post is truncated if it's in the "list view" and it has a truncate marker
+  const truncatedPost = !isBlogPostPage && hasTruncateMarker;
+
+  const tagsExists = tags.length > 0;
+
+  const renderFooter = tagsExists || truncatedPost || editUrl;
+
+  if (!renderFooter) {
+    return null;
+  }
+
+  // BlogPost footer - details view
+  if (isBlogPostPage) {
+    const canDisplayEditMetaRow = !!(editUrl || lastUpdatedAt || lastUpdatedBy);
+
+    return (
+      <footer className="docusaurus-mt-lg">
+        {tagsExists && (
+          <div
+            className={clsx(
+              'row',
+              'margin-top--sm',
+              ThemeClassNames.blog.blogFooterEditMetaRow,
+            )}>
+            <div className="col">
+              <TagsListInline tags={tags} />
+            </div>
+          </div>
+        )}
+        {canDisplayEditMetaRow && (
+          <EditMetaRow
+            className={clsx(
+              'margin-top--sm',
+              ThemeClassNames.blog.blogFooterEditMetaRow,
+            )}
+            editUrl={editUrl}
+            lastUpdatedAt={lastUpdatedAt}
+            lastUpdatedBy={lastUpdatedBy}
+          />
+        )}
+        <div className="margin-top--lg">
+          <BlogPostItemHeaderAuthors />
+        </div>
+      </footer>
+    );
+  }
+  // BlogPost footer - list view
+  else {
+    return (
+      <footer className="docusaurus-mt-lg">
+        {truncatedPost && (
+          <div className="blogPostItemReadMore">
+            <ReadMoreLink blogPostTitle={title} to={metadata.permalink} />
+            {typeof metadata.readingTime !== 'undefined' && (
+              <div className="blogPostItemReadingTime">
+                {Math.ceil(metadata.readingTime)} min read
+              </div>
+            )}
+          </div>
+        )}
+        {tagsExists && (
+          <div className="margin-top--sm">
+            <TagsListInline tags={tags} />
+          </div>
+        )}
+      </footer>
+    );
+  }
+}

--- a/src/theme/BlogPostItem/Header/Authors/index.tsx
+++ b/src/theme/BlogPostItem/Header/Authors/index.tsx
@@ -1,0 +1,47 @@
+import React, {type ReactNode} from 'react';
+import clsx from 'clsx';
+import {useBlogPost} from '@docusaurus/plugin-content-blog/client';
+import BlogAuthor from '@theme/Blog/Components/Author';
+import type {Props} from '@theme/BlogPostItem/Header/Authors';
+import styles from './styles.module.css';
+
+// Component responsible for the authors layout
+export default function BlogPostItemHeaderAuthors({
+  className,
+}: Props): ReactNode {
+  const {
+    metadata: {authors},
+    assets,
+  } = useBlogPost();
+  const authorsCount = authors.length;
+  if (authorsCount === 0) {
+    return null;
+  }
+  const imageOnly = authors.every(({name}) => !name);
+  const singleAuthor = authors.length === 1;
+  return (
+    <div
+      className={clsx(
+        'margin-top--md margin-bottom--sm',
+        imageOnly ? styles.imageOnlyAuthorRow : 'row',
+        className,
+      )}>
+      {authors.map((author, idx) => (
+        <div
+          className={clsx(
+            !imageOnly && (singleAuthor ? 'col col--12' : 'col col--6'),
+            imageOnly ? styles.imageOnlyAuthorCol : styles.authorCol,
+          )}
+          key={idx}>
+          <BlogAuthor
+            author={{
+              ...author,
+              // Handle author images using relative paths
+              imageURL: assets.authorsImageUrls[idx] ?? author.imageURL,
+            }}
+          />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/theme/BlogPostItem/Header/Authors/styles.module.css
+++ b/src/theme/BlogPostItem/Header/Authors/styles.module.css
@@ -1,0 +1,13 @@
+.authorCol {
+  max-width: inherit !important;
+}
+
+.imageOnlyAuthorRow {
+  display: flex;
+  flex-flow: row wrap;
+}
+
+.imageOnlyAuthorCol {
+  margin-left: 0.3rem;
+  margin-right: 0.3rem;
+}

--- a/src/theme/BlogPostItem/Header/Info/index.tsx
+++ b/src/theme/BlogPostItem/Header/Info/index.tsx
@@ -1,0 +1,69 @@
+import React, {type ReactNode} from 'react';
+import clsx from 'clsx';
+import {translate} from '@docusaurus/Translate';
+import {usePluralForm} from '@docusaurus/theme-common';
+import {useDateTimeFormat} from '@docusaurus/theme-common/internal';
+import {useBlogPost} from '@docusaurus/plugin-content-blog/client';
+import type {Props} from '@theme/BlogPostItem/Header/Info';
+
+import styles from './styles.module.css';
+
+// Very simple pluralization: probably good enough for now
+function useReadingTimePlural() {
+  const {selectMessage} = usePluralForm();
+  return (readingTimeFloat: number) => {
+    const readingTime = Math.ceil(readingTimeFloat);
+    return selectMessage(
+      readingTime,
+      translate(
+        {
+          id: 'theme.blog.post.readingTime.plurals',
+          description:
+            'Pluralized label for "{readingTime} min read". Use as much plural forms (separated by "|") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)',
+          message: 'One min read|{readingTime} min read',
+        },
+        {readingTime},
+      ),
+    );
+  };
+}
+
+function ReadingTime({readingTime}: {readingTime: number}) {
+  const readingTimePlural = useReadingTimePlural();
+  return <>{readingTimePlural(readingTime)}</>;
+}
+
+function DateTime({
+  date,
+  formattedDate,
+}: {
+  date: string;
+  formattedDate: string;
+}) {
+  return <time dateTime={date}>{formattedDate}</time>;
+}
+
+function Spacer() {
+  return <>{' · '}</>;
+}
+
+export default function BlogPostItemHeaderInfo({className}: Props): ReactNode {
+  const {metadata} = useBlogPost();
+  const {date, readingTime} = metadata;
+
+  const dateTimeFormat = useDateTimeFormat({
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric',
+    timeZone: 'UTC',
+  });
+
+  const formatDate = (blogDate: string) =>
+    dateTimeFormat.format(new Date(blogDate));
+
+  return (
+    <div className={clsx(styles.container, 'margin-vert--md', className)}>
+      <DateTime date={date} formattedDate={formatDate(date)} />
+    </div>
+  );
+}

--- a/src/theme/BlogPostItem/Header/Info/styles.module.css
+++ b/src/theme/BlogPostItem/Header/Info/styles.module.css
@@ -1,0 +1,3 @@
+.container {
+  font-size: 0.9rem;
+}

--- a/src/theme/BlogPostItem/Header/Title/index.tsx
+++ b/src/theme/BlogPostItem/Header/Title/index.tsx
@@ -1,0 +1,25 @@
+import React, {type ReactNode} from 'react';
+import clsx from 'clsx';
+import Link from '@docusaurus/Link';
+import {useBlogPost} from '@docusaurus/plugin-content-blog/client';
+import type {Props} from '@theme/BlogPostItem/Header/Title';
+
+import styles from './styles.module.css';
+
+export default function BlogPostItemHeaderTitle({className}: Props): ReactNode {
+  const {metadata, isBlogPostPage} = useBlogPost();
+  const {permalink, title, readingTime} = metadata;
+  const TitleHeading = isBlogPostPage ? 'h1' : 'h2';
+  return (
+    <>
+      <TitleHeading className={clsx(styles.title, className)}>
+        {isBlogPostPage ? title : <Link to={permalink}>{title}</Link>}
+      </TitleHeading>
+      {isBlogPostPage && typeof readingTime !== 'undefined' && (
+        <div className="blogPostItemReadingTime margin-bottom--md">
+          {Math.ceil(readingTime)} min read
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/theme/BlogPostItem/Header/Title/styles.module.css
+++ b/src/theme/BlogPostItem/Header/Title/styles.module.css
@@ -1,0 +1,12 @@
+.title {
+  font-size: 3rem;
+}
+
+/**
+  Blog post title should be smaller on smaller devices
+**/
+@media (max-width: 576px) {
+  .title {
+    font-size: 2rem;
+  }
+}

--- a/src/theme/BlogPostItem/Header/index.tsx
+++ b/src/theme/BlogPostItem/Header/index.tsx
@@ -1,0 +1,14 @@
+import React, {type ReactNode} from 'react';
+import {useBlogPost} from '@docusaurus/plugin-content-blog/client';
+import BlogPostItemHeaderTitle from '@theme/BlogPostItem/Header/Title';
+import BlogPostItemHeaderInfo from '@theme/BlogPostItem/Header/Info';
+import BlogPostItemHeaderAuthors from '@theme/BlogPostItem/Header/Authors';
+
+export default function BlogPostItemHeader(): ReactNode {
+  return (
+    <header>
+      <BlogPostItemHeaderTitle />
+      <BlogPostItemHeaderInfo />
+    </header>
+  );
+}

--- a/src/theme/BlogPostItem/index.tsx
+++ b/src/theme/BlogPostItem/index.tsx
@@ -1,0 +1,25 @@
+import React, {type ReactNode} from 'react';
+import clsx from 'clsx';
+import {useBlogPost} from '@docusaurus/plugin-content-blog/client';
+import BlogPostItemContainer from '@theme/BlogPostItem/Container';
+import BlogPostItemHeader from '@theme/BlogPostItem/Header';
+import BlogPostItemContent from '@theme/BlogPostItem/Content';
+import BlogPostItemFooter from '@theme/BlogPostItem/Footer';
+import type {Props} from '@theme/BlogPostItem';
+
+// apply a bottom margin in list view
+function useContainerClassName() {
+  const {isBlogPostPage} = useBlogPost();
+  return !isBlogPostPage ? 'margin-bottom--xl' : undefined;
+}
+
+export default function BlogPostItem({children, className}: Props): ReactNode {
+  const containerClassName = useContainerClassName();
+  return (
+    <BlogPostItemContainer className={clsx(containerClassName, className)}>
+      <BlogPostItemHeader />
+      <BlogPostItemContent>{children}</BlogPostItemContent>
+      <BlogPostItemFooter />
+    </BlogPostItemContainer>
+  );
+}


### PR DESCRIPTION
## Summary
- Reorder blog index: Read More link now appears above tags with larger styling
- Move reading time below Read More link on index pages and below title on blog post pages
- Hide authors from blog index, show at end of individual blog posts  
- Remove "Edit this page" links from blog posts
- Style Read More link as prominent button without border

## Test plan
- [x] Verify Read More link appears above tags on blog index
- [x] Verify reading time shows below Read More on index and below title on post pages
- [x] Verify authors are hidden on index but shown at end of individual posts
- [x] Verify "Edit this page" links are removed
- [x] Verify styling improvements for Read More button

🤖 Generated with [Claude Code](https://claude.ai/code)