### PR TITLE
Add Dependabot configuration with auto-merge workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,37 @@
+version: 2
+updates:
+  # Enable version updates for npm
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+    open-pull-requests-limit: 10
+    reviewers:
+      - "sophiedeziel"
+    assignees:
+      - "sophiedeziel"
+    commit-message:
+      prefix: "chore"
+      prefix-development: "chore"
+      include: "scope"
+    # Group minor and patch updates
+    groups:
+      docusaurus:
+        patterns:
+          - "@docusaurus/*"
+        update-types:
+          - "minor"
+          - "patch"
+      react:
+        patterns:
+          - "react*"
+        update-types:
+          - "minor"
+          - "patch"
+      development-dependencies:
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,71 @@
+name: Dependabot Auto-merge
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests and build
+        run: |
+          npm run build
+
+      - name: Get PR details
+        id: pr-details
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+            });
+            
+            const title = pr.title.toLowerCase();
+            const isMinorOrPatch = title.includes('bump') && (title.includes('minor') || title.includes('patch'));
+            const isDependencyUpdate = title.startsWith('chore(deps');
+            
+            // Check if it's a grouped update or individual minor/patch update
+            const shouldAutoMerge = isDependencyUpdate && (
+              isMinorOrPatch || 
+              title.includes('docusaurus') ||
+              title.includes('react') ||
+              title.includes('development-dependencies')
+            );
+            
+            core.setOutput('should-merge', shouldAutoMerge);
+            core.setOutput('pr-title', pr.title);
+
+      - name: Enable auto-merge for Dependabot PRs
+        if: steps.pr-details.outputs.should-merge == 'true'
+        run: |
+          echo "Auto-merging PR: ${{ steps.pr-details.outputs.pr-title }}"
+          gh pr merge --auto --squash "${{ github.event.pull_request.number }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Approve PR
+        if: steps.pr-details.outputs.should-merge == 'true'
+        run: |
+          gh pr review --approve "${{ github.event.pull_request.number }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Configure Dependabot for weekly npm dependency updates with intelligent grouping
- Add automatic merge workflow for minor and patch version updates
- Include build verification to ensure updates don't break the site

## Test plan
- [ ] Verify Dependabot configuration is valid
- [ ] Test that workflow triggers correctly on Dependabot PRs
- [ ] Confirm auto-merge only applies to minor/patch updates
- [ ] Ensure build verification runs before merge

🤖 Generated with [Claude Code](https://claude.ai/code)