### PR TITLE
Widen main layout from 1200px to 1600px

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -416,7 +416,7 @@ a[class*="tag"]:hover {
 
 /* Better spacing for main content */
 .main-wrapper {
-  max-width: 1200px;
+  max-width: 1600px;
   margin: 0 auto;
   padding: 0 2rem;
 }


### PR DESCRIPTION
## Summary

Increases the main content area max-width from 1200px to 1600px for a wider layout.

## Test plan

- [ ] Verify the site looks good on standard monitors (1920px wide)
- [ ] Verify responsive breakpoints still work on tablet and mobile
- [ ] Check blog post readability at the wider width